### PR TITLE
Give device=all permission for USB e-readers

### DIFF
--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -5,6 +5,7 @@ sdk: org.freedesktop.Sdk
 command: calibre
 separate-locales: false
 finish-args:
+  - --device=all
   - --filesystem=home
   - --share=ipc
   - --share=network


### PR DESCRIPTION
This allows Calibre to manage USB e-readers such as Kindle Fire HD.