### PR TITLE
Give filesystem=host permission for mounted e-readers

### DIFF
--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -6,7 +6,7 @@ command: calibre
 separate-locales: false
 finish-args:
   - --device=all
-  - --filesystem=home
+  - --filesystem=host
   - --share=ipc
   - --share=network
   - --socket=x11


### PR DESCRIPTION
Since we don't have a `filesystem=media` portal yet ([flatpak/flatpak#2185](https://github.com/flatpak/flatpak/issues/2185)), giving host permissions fixes #13.