### PR TITLE
Add missing permissions

### DIFF
--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -7,6 +7,7 @@ separate-locales: false
 finish-args:
   - --device=all
   - --filesystem=host
+  - --filesystem=xdg-config/kdeglobals:ro
   - --share=ipc
   - --share=network
   - --socket=x11
@@ -14,6 +15,8 @@ finish-args:
   - --system-talk-name=org.freedesktop.NetworkManager
   - --system-talk-name=org.freedesktop.UDisks2
   - --talk-name=org.freedesktop.Notifications
+  - --talk-name=com.canonical.AppMenu.Registrar
+  - --env=KDE_FORK_SLAVES=1
 modules:
   - name: calibre
     buildsystem: simple

--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -16,6 +16,8 @@ finish-args:
   - --system-talk-name=org.freedesktop.UDisks2
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=com.canonical.AppMenu.Registrar
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --own-name=org.kde.StatusNotifierItem-2-1
   - --env=KDE_FORK_SLAVES=1
 modules:
   - name: calibre


### PR DESCRIPTION
KDE flatpak runtime [sets some global permissions](https://invent.kde.org/packaging/flatpak-kde-runtime/-/blob/f3f629ddf64bc329ac45e920d3fc876ab380b634/org.kde.Sdk.json.in#L69) that are inherited for all apps that use that runtime. Since calibre flatpak uses freedekstop rutime because it bundles its own qt it should set relevant permission on its own.

This should help with https://github.com/flathub/com.calibre_ebook.calibre/issues/34