### PR TITLE
Remove org.freedesktop.Notifications dbus permission

### DIFF
--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -14,7 +14,6 @@ finish-args:
   - --socket=wayland
   - --system-talk-name=org.freedesktop.NetworkManager
   - --system-talk-name=org.freedesktop.UDisks2
-  - --talk-name=org.freedesktop.Notifications
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.kde.StatusNotifierWatcher
   - --own-name=org.kde.StatusNotifierItem-2-1


### PR DESCRIPTION
This permission is no longer necessary and it actually makes things worse with no showing icons in notifications. Calibre change: https://github.com/kovidgoyal/calibre/pull/1268

Fixes https://github.com/flathub/com.calibre_ebook.calibre/issues/38