### PR TITLE
Investigate whether shipped Liberation Fonts are necessary

### DIFF
--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -30,6 +30,10 @@ modules:
       - tar -xvf calibre*.txz -C "${FLATPAK_DEST}/lib/calibre"
       - rm -f calibre*.txz
 
+      # Reuse liberation font files from runtime (saves 4MB)
+      - rm "${FLATPAK_DEST}/lib/calibre/resources/fonts/liberation"/*.ttf
+      - ln -s /usr/share/fonts/liberation-fonts/*.ttf "${FLATPAK_DEST}/lib/calibre/resources/fonts/liberation/"
+
       # Ensure that Calibre install script and the `xdg-utils` it uses will not
       # report errors because they are unable to find any suitable destination
       # directory to place their files into


### PR DESCRIPTION
As part of #66, I proposed dropping `/share/calibre/fonts/liberation` from the Flatpak, since these files are already shipped (and apparently in a more recent version) in the FD runtime. In order to move forward with that request, it was decided to postpone the decision however.

Based on this I have some questions to @kovidgoyal:

  1. What are these files used for? Do they only act as a fallback to the system font resolution or are they referenced directly in some way that makes it essential to remain at the given path?
  2. If the former is true: Do you consider the presence of these files as essential for a complete Calibre distribution, even if it is guaranteed that a newer version of these fonts is always always available in the target environment?
  3. If the later is true: Would replacing them with a symlink (like Fedora and Debian apparently do) to their location in the platform image be considered an acceptable alternative to shipping them unmodified?