### PR TITLE
Explicitly allow dri device access

### DIFF
--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -6,6 +6,7 @@ command: calibre
 separate-locales: false
 finish-args:
   - --device=all
+  - --device=dri
   - --filesystem=host
   - --filesystem=xdg-config/kdeglobals:ro
   - --share=ipc


### PR DESCRIPTION
DRI device access should be set explicitly so 3D HW acceleration won't
break when the user globally blocked the permissive --device=all
permission.