### PR TITLE
Add tmp folder in flatpak

### DIFF
--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -20,6 +20,7 @@ finish-args:
   - --own-name=org.kde.StatusNotifierItem-2-1
   - --env=KDE_FORK_SLAVES=1
   - --env=SSL_CERT_DIR=/etc/ssl/certs
+  - --env=CALIBRE_TEMP_DIR=/run/user/1000/app/com.calibre_ebook.calibre
 modules:
   - name: calibre
     buildsystem: simple

--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -82,6 +82,9 @@ modules:
     cleanup:
       - /bin/calibre-uninstall
       - /share/applications/mimeinfo.cache
+    post-install:
+      - mv /app/bin/calibre /app/bin/calibre-bin
+      - install -Dm755 ../calibre-wrapper /app/bin/calibre
     sources:
       - type: file
         only-arches:
@@ -93,9 +96,6 @@ modules:
           version-pattern: The latest release of calibre is ((?:\d+\.)?(?:\d+\.)?\d+)
           url-template: https://download.calibre-ebook.com/$version/calibre-$version-x86_64.txz
         sha256: f4cd41d01a434d61572dc49fbb52949b97c8ebc4656445a4a90bcb84032f7614
-        post-install:
-          - mv /app/bin/calibre /app/bin/calibre-bin
-          - install -Dm755 ../calibre-wrapper /app/bin/calibre
       - type: script
         dest-filename: calibre-wrapper
         commands:

--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -20,7 +20,6 @@ finish-args:
   - --own-name=org.kde.StatusNotifierItem-2-1
   - --env=KDE_FORK_SLAVES=1
   - --env=SSL_CERT_DIR=/etc/ssl/certs
-  - --env=CALIBRE_TEMP_DIR=/run/user/1000/app/com.calibre_ebook.calibre
 modules:
   - name: calibre
     buildsystem: simple
@@ -94,6 +93,15 @@ modules:
           version-pattern: The latest release of calibre is ((?:\d+\.)?(?:\d+\.)?\d+)
           url-template: https://download.calibre-ebook.com/$version/calibre-$version-x86_64.txz
         sha256: f4cd41d01a434d61572dc49fbb52949b97c8ebc4656445a4a90bcb84032f7614
+        post-install:
+          - mv /app/bin/calibre /app/bin/calibre-bin
+          - install -Dm755 ../calibre-wrapper /app/bin/calibre
+      - type: script
+        dest-filename: calibre-wrapper
+        commands:
+          - 'export CALIBRE_TEMP_DIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"'
+          - 'exec /app/bin/calibre-bin "$@"'
+
     modules:
       # Required by post-installation script only
       - name: xdg-utils

--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -84,7 +84,7 @@ modules:
       - /share/applications/mimeinfo.cache
     post-install:
       - mv /app/bin/calibre /app/bin/calibre-bin
-      - install -Dm755 ../calibre-wrapper /app/bin/calibre
+      - install -Dm755 calibre-wrapper /app/bin/calibre
     sources:
       - type: file
         only-arches:


### PR DESCRIPTION
Some extensions/import functions use tmp files.
the base folder is set in an env variable.
If this is distro-agnostic enough?
It works on my system (ubuntu 21.04)