### PR TITLE
Add Trash access

### DIFF
--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -14,6 +14,7 @@ finish-args:
   - --socket=x11
   - --socket=wayland
   - --filesystem=xdg-run/speech-dispatcher:ro
+  - --filesystem=xdg-data/Trash
   - --system-talk-name=org.freedesktop.UDisks2
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.kde.StatusNotifierWatcher


### PR DESCRIPTION
This ensures deleted files go to actual Trash instead of private folder in app config path.

Note that Trash folder is already accessible through` --filesystem=host` so this doesn't weaken sandbox. Additional permission is needed for bind-mounting Trash folder to another place in order to make it recognizable in flatpak environment.
  
Fixes https://github.com/flathub/com.calibre_ebook.calibre/issues/83