### PR TITLE
Ignore openssl config from runtime

### DIFF
--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -20,6 +20,7 @@ finish-args:
   - --own-name=org.kde.*
   - --env=KDE_FORK_SLAVES=1
   - --env=SSL_CERT_DIR=/etc/ssl/certs
+  - --env=OPENSSL_CONF=/dev/null
 modules:
   - name: calibre
     buildsystem: simple


### PR DESCRIPTION
Runtime openssl config loads p11kit engine for openssl v3 while calibre uses opensslv 1.1 which may result in crash.

Fixes https://github.com/flathub/com.calibre_ebook.calibre/issues/158