### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -17,7 +17,6 @@ finish-args:
   - --system-talk-name=org.freedesktop.UDisks2
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --own-name=org.kde.*
   - --env=KDE_FORK_SLAVES=1
   - --env=SSL_CERT_DIR=/etc/ssl/certs
   - --env=OPENSSL_CONF=/dev/null


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/66#issuecomment-1386033025