### PR TITLE
Fix mangled metainfo file

### DIFF
--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -69,7 +69,7 @@ modules:
       - desktop-file-edit --set-key Icon --set-value $FLATPAK_ID $FLATPAK_DEST/share/applications/$FLATPAK_ID.desktop
 
       # post-install for metainfo
-      - mv $FLATPAK_DEST/share/metainfo/{calibre-gui,$FLATPAK_ID}.metainfo.xml
+      - cp $FLATPAK_DEST/share/metainfo/{calibre-gui,$FLATPAK_ID}.metainfo.xml
       - appstream-util modify $FLATPAK_DEST/share/metainfo/$FLATPAK_ID.metainfo.xml
         id $FLATPAK_ID
       - appstream-util modify $FLATPAK_DEST/share/metainfo/$FLATPAK_ID.metainfo.xml

--- a/com.calibre_ebook.calibre.yaml
+++ b/com.calibre_ebook.calibre.yaml
@@ -74,8 +74,6 @@ modules:
         id $FLATPAK_ID
       - appstream-util modify $FLATPAK_DEST/share/metainfo/$FLATPAK_ID.metainfo.xml
         launchable $FLATPAK_ID.desktop
-      - appstream-util add-provide $FLATPAK_DEST/share/metainfo/${FLATPAK_ID}.metainfo.xml
-        id calibre-gui.desktop
 
       # post-install for MIME types
       - mv $FLATPAK_DEST/share/mime/packages/{calibre-mimetypes,$FLATPAK_ID}.xml


### PR DESCRIPTION
It turns out that `add-provide` subcommand of `appstream-util` mangles metainfo file which results in lost of important info like release changelogs.

The provide section doesn't look like something required so hopefully it can be dropped.